### PR TITLE
Fix error when multiple directory found at \AppData\Roaming\EldenRing

### DIFF
--- a/EldenRingSaveBackupTool.ps1
+++ b/EldenRingSaveBackupTool.ps1
@@ -18,13 +18,35 @@ $backupSeamlessCoop = $true
 
 $backupVanilla = $true
 
+#Change if does crash or give errors about "$erSavePath = Join-Path -Path $erBasePath -ChildPath $userID"
+
+$Multyple_Directory = $false
+#After change the $Directory
+
+#Change $Directory to select the only one you need, this mod actualy crash/dont work if you do have more the 1 directory at C:\Users\<...>\AppData\Roaming\EldenRing
+
+$Directory = "\"
+# example $Directory = "\76561198246504570" !Note use the \before the directory name
 
 #Don't change below code
 ###################################################################
 
 $delaySeconds = $delayMinutesBetweenBackups * 60
 $erBasePath = Join-Path -Path $env:APPDATA -ChildPath "\EldenRing"
-$userID = Get-ChildItem -Path $erBasePath -Name -Directory
+
+if($Multyple_Directory){
+	
+	<# Force directory#>
+	$userID = Get-ChildItem -Path (Join-Path -Path $erBasePath -ChildPath $Directory ) -Name -Directory 
+	Write-Host "Forced directory selected."
+	
+}else {
+	
+	<# Auto directory#>
+	$userID = Get-ChildItem -Path $erBasePath -Name -Directory
+	Write-Host "Automatic directory selected."
+}
+
 $erSavePath = Join-Path -Path $erBasePath -ChildPath $userID
 $deletePathSeamless = [IO.Path]::Combine($backupDirectory, '*\', '*.co2')
 $deletePathVanilla = [IO.Path]::Combine($backupDirectory, '*\', '*.sl2')

--- a/EldenRingSaveBackupTool.ps1
+++ b/EldenRingSaveBackupTool.ps1
@@ -25,8 +25,8 @@ $Multyple_Directory = $false
 
 #Change $Directory to select the only one you need, this mod actualy crash/dont work if you do have more the 1 directory at C:\Users\<...>\AppData\Roaming\EldenRing
 
-$Directory = "\"
-# example $Directory = "\76561198246504570" !Note use the \before the directory name
+$Directory = ""
+# example $Directory = "76561198246504570"
 
 #Don't change below code
 ###################################################################
@@ -37,14 +37,15 @@ $erBasePath = Join-Path -Path $env:APPDATA -ChildPath "\EldenRing"
 if($Multyple_Directory){
 	
 	<# Force directory#>
-	$userID = Get-ChildItem -Path (Join-Path -Path $erBasePath -ChildPath $Directory ) -Name -Directory 
 	Write-Host "Forced directory selected."
+	$userID = Get-ChildItem -Path $erBasePath -Name -Directory -Filter $Directory
 	
 }else {
 	
 	<# Auto directory#>
-	$userID = Get-ChildItem -Path $erBasePath -Name -Directory
 	Write-Host "Automatic directory selected."
+	$userID = Get-ChildItem -Path $erBasePath -Name -Directory
+	
 }
 
 $erSavePath = Join-Path -Path $erBasePath -ChildPath $userID


### PR DESCRIPTION
I had this error:
Join-Path : Impossibile convertire 'System.Object[]' nel tipo 'System.String' richiesto da parametro 'ChildPath'.
Specificato metodo non supportato.
In G:\SteamLibrary\steamapps\common\ELDEN RING\Game\EldenRingSaveBackupTool.ps1:28 car:54
 $erSavePath = Join-Path -Path $erBasePath -ChildPath $userID
                                                      ~~~~~~~
     CategoryInfo          : InvalidArgument: (:) [Join-Path], ParameterBindingException
     FullyQualifiedErrorId : CannotConvertArgument,Microsoft.PowerShell.Commands.JoinPathCommand
    
So I figured out how to fix it, now works but not in the most polished work I have ever done.
I have no clue how to code in PowerShell.